### PR TITLE
Don't require the latest version of brakeman.

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -5,6 +5,4 @@
 require "rubygems"
 require "bundler/setup"
 
-ARGV.unshift("--ensure-latest")
-
 load Gem.bin_path("brakeman", "brakeman")


### PR DESCRIPTION
It's annoying to break CI when the version is outdated, especially since Dependabot will let you know it's outdated.