### PR TITLE
Exclude the tmp/ directory from RuboCop.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ AllCops:
     - "db/*schema.rb"
     - "node_modules/**/*"
     - "vendor/**/*"
+    - "tmp/**/*"
   NewCops: enable
 
 Layout/HashAlignment:


### PR DESCRIPTION
Noticed cache files significantly slowing down runs locally.